### PR TITLE
"google.*"のような全てのTLDを網羅するルールを追加

### DIFF
--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -16,6 +16,7 @@ const blacklist = [
     "||googledrive.com",
     "||googleearth.com",
     "||googlefonts.com",
+    /^https?:\/\/(\w*\.)*(google)(\.\w{1,3}){1,2}\//
 ] as (RegExp | string)[];
 
 const json = blacklist.map((e,i)=>({


### PR DESCRIPTION

https://github.com/TNTSuperMan/gBlocker/issues/1

このIssueの解決のため、google.co.jp等の全てのTLDを網羅するルールを追加しました。