### PR TITLE
ブロックリストを全て正規表現に統一・ビルドスクリプトとブロックリストを分割

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -1,4 +1,17 @@
 import { file, write } from "bun";
-import"./src/blocks";
+import { blacklist } from "./src/blocks";
+
+const json = blacklist.map((e,i)=>({
+    id: i+1,
+    priority: 1,
+    action: { type: "block" },
+    condition: {
+        regexFilter: e instanceof RegExp ? e.source : undefined,
+        urlFilter: typeof e === "string" ? e : undefined,
+        resourceTypes: [ "main_frame", "sub_frame", "stylesheet", "script", "image", "font", "object", "xmlhttprequest", "ping", "csp_report", "media", "websocket", "webtransport", "webbundle", "other" ]
+    }
+}))
+
+write("./dist/block.json", JSON.stringify(json));
 
 write("./dist/manifest.json", file("./manifest.json"));

--- a/build.ts
+++ b/build.ts
@@ -6,8 +6,7 @@ const json = blacklist.map((e,i)=>({
     priority: 1,
     action: { type: "block" },
     condition: {
-        regexFilter: e instanceof RegExp ? e.source : undefined,
-        urlFilter: typeof e === "string" ? e : undefined,
+        regexFilter: e.source,
         resourceTypes: [ "main_frame", "sub_frame", "stylesheet", "script", "image", "font", "object", "xmlhttprequest", "ping", "csp_report", "media", "websocket", "webtransport", "webbundle", "other" ]
     }
 }))

--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -2,7 +2,7 @@ import { write } from "bun";
 
 const blacklist = [
     /^https?:\/\/(\w*\.)*(google|google-analytics|googletagmanager|youtube|googlesyndication|doubleclick|gstatic|googleapis|googleusercontent|googleemail|googlecode|googlehosted|googledrive|googleearth|googlefonts)(\.\w{1,3}){1,2}\//,
-] as (RegExp | string)[];
+] as RegExp[];
 
 const json = blacklist.map((e,i)=>({
     id: i+1,

--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -1,21 +1,7 @@
 import { write } from "bun";
 
 const blacklist = [
-    /^https?:\/\/(\w*\.)*(google)(\.\w{1,3}){1,2}\//,
-    "||google-analytics.com",
-    "||googletagmanager.com",
-    "||youtube.com",
-    "||googlesyndication.com",
-    "||doubleclick.net",
-    "||gstatic.com",
-    "||googleapis.com",
-    "||googleusercontent.com",
-    "||googleemail.com",
-    "||googlecode.com",
-    "||googlehosted.com",
-    "||googledrive.com",
-    "||googleearth.com",
-    "||googlefonts.com",
+    /^https?:\/\/(\w*\.)*(google|google-analytics|googletagmanager|youtube|googlesyndication|doubleclick|gstatic|googleapis|googleusercontent|googleemail|googlecode|googlehosted|googledrive|googleearth|googlefonts)(\.\w{1,3}){1,2}\//,
 ] as (RegExp | string)[];
 
 const json = blacklist.map((e,i)=>({

--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -1,7 +1,7 @@
 import { write } from "bun";
 
 const blacklist = [
-    "||google.com",
+    /^https?:\/\/(\w*\.)*(google)(\.\w{1,3}){1,2}\//,
     "||google-analytics.com",
     "||googletagmanager.com",
     "||youtube.com",
@@ -16,7 +16,6 @@ const blacklist = [
     "||googledrive.com",
     "||googleearth.com",
     "||googlefonts.com",
-    /^https?:\/\/(\w*\.)*(google)(\.\w{1,3}){1,2}\//
 ] as (RegExp | string)[];
 
 const json = blacklist.map((e,i)=>({

--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -1,18 +1,3 @@
-import { write } from "bun";
-
-const blacklist = [
+export const blacklist = [
     /^https?:\/\/(\w*\.)*(google|google-analytics|googletagmanager|youtube|googlesyndication|doubleclick|gstatic|googleapis|googleusercontent|googleemail|googlecode|googlehosted|googledrive|googleearth|googlefonts)(\.\w{1,3}){1,2}\//,
 ] as RegExp[];
-
-const json = blacklist.map((e,i)=>({
-    id: i+1,
-    priority: 1,
-    action: { type: "block" },
-    condition: {
-        regexFilter: e instanceof RegExp ? e.source : undefined,
-        urlFilter: typeof e === "string" ? e : undefined,
-        resourceTypes: [ "main_frame", "sub_frame", "stylesheet", "script", "image", "font", "object", "xmlhttprequest", "ping", "csp_report", "media", "websocket", "webtransport", "webbundle", "other" ]
-    }
-}))
-
-write("./dist/block.json", JSON.stringify(json));


### PR DESCRIPTION
#3 を解決するためにブロックリストを正規表現に統一し、
提案理由であるテストを容易にするためにビルド系とブロックリストを切り離しました。