### PR TITLE
検出するTLDの長さを増やす

### DIFF
--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -1,3 +1,3 @@
 export const blacklist = [
-    /^https?:\/\/(\w*\.)*(google|google-analytics|googletagmanager|youtube|googlesyndication|doubleclick|gstatic|googleapis|googleusercontent|googleemail|googlecode|googlehosted|googledrive|googleearth|googlefonts)(\.\w{1,3}){1,2}\//,
+    /^https?:\/\/(\w*\.)*(google|google-analytics|googletagmanager|youtube|googlesyndication|doubleclick|gstatic|googleapis|googleusercontent|googleemail|googlecode|googlehosted|googledrive|googleearth|googlefonts)(\.\w{1,5}){1,5}\//,
 ] as RegExp[];


### PR DESCRIPTION
#6 これの解決のため、検出するTLDの長さを5文字に増やしました。