### PR TITLE
正規表現を2KB以下に抑える

### DIFF
--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -1,5 +1,5 @@
 const gen_reg = (name: string) =>
-    new RegExp(`^https?://(\\w*\\.)*${name}(\\.\\w{1,5}){1,5}/?`)
+    new RegExp(`^https?:\\/\\/(?:\\w+\\.)*${name}(?:\\.\\w{2,5})+`)
 
 export const blacklist = [
     ...[

--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -1,3 +1,6 @@
+const gen_reg = (name: string) =>
+    new RegExp(`^https?://(\\w*\\.)*${name}(\\.\\w{1,5}){1,5}/?`)
+
 export const blacklist = [
     /^https?:\/\/(\w*\.)*(google|google-analytics|googletagmanager|youtube|googlesyndication|doubleclick|gstatic|googleapis|googleusercontent|googleemail|googlecode|googlehosted|googledrive|googleearth|googlefonts)(\.\w{1,5}){1,5}\//,
 ] as RegExp[];

--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -2,5 +2,21 @@ const gen_reg = (name: string) =>
     new RegExp(`^https?://(\\w*\\.)*${name}(\\.\\w{1,5}){1,5}/?`)
 
 export const blacklist = [
-    /^https?:\/\/(\w*\.)*(google|google-analytics|googletagmanager|youtube|googlesyndication|doubleclick|gstatic|googleapis|googleusercontent|googleemail|googlecode|googlehosted|googledrive|googleearth|googlefonts)(\.\w{1,5}){1,5}\//,
+    ...[
+        "google",
+        "google-analytics",
+        "googletagmanager",
+        "youtube",
+        "googlesyndication",
+        "doubleclick",
+        "gstatic",
+        "googleapis",
+        "googleusercontent",
+        "googleemail",
+        "googlecode",
+        "googlehosted",
+        "googledrive",
+        "googleearth",
+        "googlefonts",
+    ].map(gen_reg)
 ] as RegExp[];

--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -1,5 +1,5 @@
 const gen_reg = (name: string) =>
-    new RegExp(`^https?:\\/\\/(?:\\w+\\.)*${name}(?:\\.\\w{2,5})+`)
+    new RegExp(`^https?:\\/\\/(?:\\w+\\.)*${name}(?:\\.\\w{2,5})+(?:\\/|$)`)
 
 export const blacklist = [
     ...[


### PR DESCRIPTION
#8 を解決するため、以下をしました。
- 正規表現の原型の統一
- 非グルーピングにする
- 一つにまとまっていた正規表現を分ける